### PR TITLE
Splitting front matter and body: More precision

### DIFF
--- a/src/lib/Posts.hs
+++ b/src/lib/Posts.hs
@@ -13,6 +13,8 @@ import           Data.List as List
 import           Data.Char
 import           Data.Map as Map
 import           Data.Maybe
+import Control.Monad  (join)
+import Data.Bifunctor (bimap)
 
 findPosts :: FilePath -> IO [FilePath]
 findPosts = getDirectoryContents
@@ -33,13 +35,12 @@ joinLines :: [String] -> String
 joinLines = intercalate "\n"
 
 splitFrontMatterAndBody :: String -> (String, String)
-splitFrontMatterAndBody s = unlineTuple $ toTuple (indices asLines) asLines
+splitFrontMatterAndBody s = join bimap joinLines $ toTuple (indices asLines) asLines
   where
     asLines = lines s
     indices = findIndices (startsWith "+++")
     toTuple (x:y:_) ls = (takeBetween x y ls, drop (y + 1) ls)
     toTuple xs ls = (ls, [])
-    unlineTuple (x, y) = (joinLines x, joinLines y)
 
 trim :: String -> String
 trim = trimL . trimR

--- a/src/lib/Posts.hs
+++ b/src/lib/Posts.hs
@@ -40,19 +40,7 @@ splitFrontMatterAndBody s = join bimap joinLines $ toTuple (indices asLines) asL
     asLines = lines s
     indices = findIndices (startsWith "+++")
     toTuple (x:y:_) ls = (takeBetween x y ls, drop (y + 1) ls)
-    toTuple xs ls = (ls, [])
-
-trim :: String -> String
-trim = trimL . trimR
-
-trimL :: String -> String
-trimL = dropWhile isSpace
-
-trimR :: String -> String
-trimR = reverse . trimL . reverse
-
-notEmpty :: String -> Bool
-notEmpty str = str /= ""
+    toTuple _ ls = (ls, [])
 
 extractFrontmatter :: String -> String
 extractFrontmatter = fst . splitFrontMatterAndBody

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -8,7 +8,7 @@ import Data.Map
 import Posts
 
 content :: String
-content = "+++ category=[\"travel\"] +++ This is my body."
+content = "+++\ncategory=[\"travel\"]\n+++\nThis is my body."
 
 suite :: TestTree
 suite = testGroup "Posts"


### PR DESCRIPTION
- Updates the test to reflect the reality better (`+++` followed by a `\n`) and tries a different approach when splitting the frontmatter, which is probably also a bit more robust and precise.

7fd2e83a5ec0576891453e091952cdb70e784868 holds some type system magic - hard to understand on first glance.